### PR TITLE
Refactor models: enums and property updates

### DIFF
--- a/ConstructEd.Model/Course.cs
+++ b/ConstructEd.Model/Course.cs
@@ -1,16 +1,32 @@
-﻿namespace ConstructEd.Models
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace ConstructEd.Models
 {
+    public enum Category
+    {
+        Construction,
+        Engineering,
+        Architecture,
+        ProjectManagement,
+        Safety,
+        Sustainability,
+        Technology,
+        Other
+    }
     public class Course
     {
+        [Key]
         public int Id { get; set; }
         public string Title { get; set; }
         public string Description { get; set; }
         public decimal Price { get; set; }
-        public string Duration { get; set; }
-        public string Category { get; set; }
-        public DateTime CreatedAt { get; set; }
-        public DateTime UpdatedAt { get; set; }
-        public ICollection<Enrollment> Enrollments { get; set; }
-        public ICollection<CourseContent> CourseContents { get; set; }
+        public TimeSpan Duration { get; set; }
+        public bool IsActive { get; set; } 
+        public Category Category { get; set; }
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+        public IEnumerable<Enrollment> Enrollments { get; set; } 
+
+        public IEnumerable<CourseContent> CourseContents { get; set; } 
     }
 }

--- a/ConstructEd.Model/CourseContent.cs
+++ b/ConstructEd.Model/CourseContent.cs
@@ -1,14 +1,26 @@
-﻿namespace ConstructEd.Models
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace ConstructEd.Models
 {
+    public enum ContentType
+    {
+        Video,
+        Document,
+        Quiz,
+        Assignment
+    }
     public class CourseContent
     {
+        [Key]
         public int Id { get; set; }
         public string Title { get; set; }
-        public string Type { get; set; }
+        public ContentType Type { get; set; }
         public string FileUrl { get; set; }
         public int Order { get; set; }
 
         // Navigation Properties
+        [ForeignKey("Course")]
         public int CourseId { get; set; }
         public Course Course { get; set; }
     }

--- a/ConstructEd.Model/Enrollment.cs
+++ b/ConstructEd.Model/Enrollment.cs
@@ -1,13 +1,20 @@
-﻿namespace ConstructEd.Models
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace ConstructEd.Models
 {
     public class Enrollment
     {
+        [Key]
         public int Id { get; set; }
+
+        [ForeignKey("Course")]
         public int CourseId { get; set; }
         public DateTime EnrollmentDate { get; set; }
         public int Progress { get; set; }
 
         // Navigation Properties
+        [ForeignKey("User")]
         public string UserId { get; set; }
         public ApplicationUser User { get; set; }
         public Course Course { get; set; }

--- a/ConstructEd.Model/Payment.cs
+++ b/ConstructEd.Model/Payment.cs
@@ -1,16 +1,32 @@
-﻿namespace ConstructEd.Models
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace ConstructEd.Models
 {
+    public enum PaymentStatus
+    {
+        Pending,
+        Completed,
+        Failed
+    }
     public class Payment
     {
+        [Key]
         public int Id { get; set; }
+
+        [ForeignKey("Course")]
         public int CourseId { get; set; }
         public decimal Amount { get; set; }
         public DateTime PaymentDate { get; set; }
         public string TransactionId { get; set; }
+        public PaymentStatus Status { get; set; }
 
         // Navigation Properties
         public string UserId { get; set; }
+
+        [ForeignKey("User")]
         public ApplicationUser User { get; set; }
         public Course Course { get; set; }
+
     }
 }


### PR DESCRIPTION
- Updated `Course` class to use `Category` enum, changed `Duration` to `TimeSpan`, added `IsActive`, and set default values for `CreatedAt` and `UpdatedAt`. Changed `Enrollments` and `CourseContents` to `IEnumerable`.
- Introduced `ContentType` enum in `CourseContent`, replacing the string-based `Type`.
- Modified `Enrollment` class to include foreign keys for `Course` and `User`, with `Id` marked as `[Key]`.
- Added `PaymentStatus` enum in `Payment`, replacing the string-based status, and established foreign key relationships for `Course` and `User`, with `Id` marked as `[Key]`.