### PR TITLE
Remove EnrollmentDate, vsav project, and clean IRepository

### DIFF
--- a/ConstructEd.Model/Enrollment.cs
+++ b/ConstructEd.Model/Enrollment.cs
@@ -7,8 +7,6 @@ namespace ConstructEd.Models
     {
         [Key]
         public int Id { get; set; }
-
-     
         public DateTime EnrollmentDate { get; set; } = DateTime.UtcNow;
         public int Progress { get; set; }
 

--- a/ConstructEd.sln
+++ b/ConstructEd.sln
@@ -9,8 +9,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConstructEd.Data", "Context
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConstructEd.Models", "ConstructEd.Model\ConstructEd.Models.csproj", "{993FE232-C186-43A5-B471-C1A581C0359B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "vsav", "vsav\vsav.csproj", "{360C2462-35C5-4893-B6C9-F1F20FCED91B}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,10 +27,6 @@ Global
 		{993FE232-C186-43A5-B471-C1A581C0359B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{993FE232-C186-43A5-B471-C1A581C0359B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{993FE232-C186-43A5-B471-C1A581C0359B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{360C2462-35C5-4893-B6C9-F1F20FCED91B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{360C2462-35C5-4893-B6C9-F1F20FCED91B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{360C2462-35C5-4893-B6C9-F1F20FCED91B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{360C2462-35C5-4893-B6C9-F1F20FCED91B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ConstructEd/Repositories/IRepository.cs
+++ b/ConstructEd/Repositories/IRepository.cs
@@ -1,20 +1,17 @@
-﻿
-
-namespace ConstructEd.Repositories
-
+﻿namespace ConstructEd.Repositories
 {
     public interface IRepository<T>
     {
         ICollection<T> GetAll();
-        
+
         T GetById(int id);
-        
+
         void Insert(T obj);
-        
+
         void Update(T obj);
-        
+
         void Delete(int id);
-        
+
         int Save();
     }
 }


### PR DESCRIPTION
Removed the EnrollmentDate property from the Enrollment class in the ConstructEd.Models namespace. This property was previously set to the current UTC date and time by default.

Removed the vsav project from the ConstructEd.sln solution file, including its Debug and Release build configurations.

Cleaned up the IRepository interface in the ConstructEd.Repositories namespace by removing unnecessary blank lines and correcting the namespace declaration.